### PR TITLE
Fixed a bug that allowed players to get any head

### DIFF
--- a/DreamVIPStuff/src/main/kotlin/net/perfectdreams/dreamvipstuff/commands/CabecasPersonalizadasCommand.kt
+++ b/DreamVIPStuff/src/main/kotlin/net/perfectdreams/dreamvipstuff/commands/CabecasPersonalizadasCommand.kt
@@ -42,7 +42,7 @@ object CabecasPersonalizadasCommand : DSLCommandBase<DreamVIPStuff> {
             }
 
             if (url != null) {
-                if (!url.contains("://minecraft-heads.com/custom-heads/")) {
+                if (!url.startsWith("https://minecraft-heads.com/custom-heads/")) {
                     player.sendMessage("§6/vipcabeças url")
                     player.sendMessage("§cCada cabeça custa 10k sonhos")
                     player.sendMessage("§cEnvie URLs do https://minecraft-heads.com/ da seção de \"Custom Heads\"!")


### PR DESCRIPTION
I have fixed a simple, yet still "useful", exploit that allowed players to grab anyone's head. Basically, the code only checked if the URL contained "://minecraft-heads.com/custom-heads/". For instance, if you type "/vipcabeças https://rb.gy/xmkym0?://minecraft-heads.com/custom-heads/", you would be able to get yNilzinha_'s head. That shortened URL leads to a website of mine: https://brenosantos.com.br/assets/head.txt.

I have "injected" (read: modified two strings) the UUID of yNilzinha_'s skin there, and by doing so, when the plugin reads the html code in there, it grabs her head.