### PR TITLE
Fixed a slight inconvenience during "evento chat"

### DIFF
--- a/DreamChat/src/main/kotlin/net/perfectdreams/dreamchat/listeners/ChatListener.kt
+++ b/DreamChat/src/main/kotlin/net/perfectdreams/dreamchat/listeners/ChatListener.kt
@@ -81,7 +81,7 @@ class ChatListener(val m: DreamChat) : Listener {
 			e.tags.add(
 				PlayerTag(
 					"§b§lD",
-					"§b§lDatilógrafo",
+					"§b§lDatilógraf${player.artigo}",
 					listOf(
 						"§r§b${e.player.displayName}§r§7 ficou atento no chat e",
 						"§7e preparad${e.player.artigo} no teclado para conseguir",
@@ -281,7 +281,7 @@ class ChatListener(val m: DreamChat) : Listener {
 			event.tags.add(
 				PlayerTag(
 					"§2§lL",
-					"§2§lLuxuoso",
+					"§2§lLuxuos${player.artigo}",
 					listOf(
 						"§r§b${player.displayName}§r§7 é a segunda pessoa mais rica do §4§lSparkly§b§lPower§r§7!",
 						"",
@@ -297,7 +297,7 @@ class ChatListener(val m: DreamChat) : Listener {
 			event.tags.add(
 				PlayerTag(
 					"§2§lB",
-					"§2§lBurguês",
+					"§2§l${if (!player.girl) { "Burguês" } else { "Burguesa" }}",
 					listOf(
 						"§r§b${player.displayName}§r§7 é a terceira pessoa mais rica do §4§lSparkly§b§lPower§r§7!",
 						"",

--- a/DreamChat/src/main/kotlin/net/perfectdreams/dreamchat/listeners/ChatListener.kt
+++ b/DreamChat/src/main/kotlin/net/perfectdreams/dreamchat/listeners/ChatListener.kt
@@ -146,7 +146,7 @@ class ChatListener(val m: DreamChat) : Listener {
 		if (3500 >= diff) {
 			val lastMessageContent = lastMessageCache[player]
 			if (lastMessageContent != null) {
-				if (5 > StringUtils.getLevenshteinDistance(lastMessageContent, message)) {
+				if (5 > StringUtils.getLevenshteinDistance(lastMessageContent, message) && !m.eventoChat.running) {
 					player.sendMessage("§cNão mande mensagens iguais ou similares a última que você mandou!")
 					return
 				}


### PR DESCRIPTION
If you misspell during the event, and then correct it afterwards, the plugin will block your message due to its similarity with the previous message.

![as_to_avoid_this](https://user-images.githubusercontent.com/49931961/106516689-05824a80-649d-11eb-87cd-590c8424f5b7.PNG)

My suggestion is to impede this behaviour by disabling the verification when the event is happening. It is not really a big deal, but some players (it might be a prank, but your never know) like to accuse others of hacking when this happens. It is rather annoying, so correcting it would stop the slight annoyance.