### PR TITLE
Sugestão do Winzler

### DIFF
--- a/bukkit/DreamClubes/src/main/kotlin/net/perfectdreams/dreamclubes/commands/subcommands/NameSubCommand.kt
+++ b/bukkit/DreamClubes/src/main/kotlin/net/perfectdreams/dreamclubes/commands/subcommands/NameSubCommand.kt
@@ -24,7 +24,7 @@ class NameSubCommand(val m: DreamClubes) : WithClubeSubCommand {
         val name = args.joinToString(" ")
 
         async {
-            if (!selfMember.canExecute(ClubePermissionLevel.OWNER)) { // Sem permissão
+            if (!selfMember.canExecute(ClubePermissionLevel.ADMIN)) { // Sem permissão
                 player.sendMessage("${DreamClubes.PREFIX} §cVocê não tem permissão!")
                 return@async
             }

--- a/bukkit/DreamClubes/src/main/kotlin/net/perfectdreams/dreamclubes/commands/subcommands/TagSubCommand.kt
+++ b/bukkit/DreamClubes/src/main/kotlin/net/perfectdreams/dreamclubes/commands/subcommands/TagSubCommand.kt
@@ -24,7 +24,7 @@ class TagSubCommand(val m: DreamClubes) : WithClubeSubCommand {
         val tag = args.getOrNull(0) ?: return
 
         async {
-            if (!selfMember.canExecute(ClubePermissionLevel.OWNER)) { // Sem permissão
+            if (!selfMember.canExecute(ClubePermissionLevel.ADMIN)) { // Sem permissão
                 player.sendMessage("${DreamClubes.PREFIX} §cVocê não tem permissão!")
                 return@async
             }


### PR DESCRIPTION
A sugestão consistia em dar todas as permissões do DONO do clã para o ADMINISTRADOR também (exceto a permissão de deletar o clã). Como cada comando tem sua permissão individual, eu apenas alterei as permissões dos únicos comandos que o ADMINISTRADOR não conseguia executar, que são:

-Alterar nome do CLÃ
-Alterar TAG do CLÃ