### PR TITLE
Fix dream terrain addition listener not registering

### DIFF
--- a/bukkit/DreamTerrainAdditions/src/main/kotlin/net/perfectdreams/dreamterrainadditions/DreamTerrainAdditions.kt
+++ b/bukkit/DreamTerrainAdditions/src/main/kotlin/net/perfectdreams/dreamterrainadditions/DreamTerrainAdditions.kt
@@ -3,17 +3,15 @@ package net.perfectdreams.dreamterrainadditions
 import com.okkero.skedule.SynchronizationContext
 import com.okkero.skedule.schedule
 import kotlinx.coroutines.sync.Mutex
-import kotlinx.serialization.*
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import me.ryanhamshire.GriefPrevention.ClaimPermission
 import me.ryanhamshire.GriefPrevention.GriefPrevention
-import me.ryanhamshire.GriefPrevention.events.TrustChangedEvent
-import net.perfectdreams.dreamcore.utils.*
+import net.perfectdreams.dreamcore.utils.KotlinPlugin
+import net.perfectdreams.dreamcore.utils.registerEvents
+import net.perfectdreams.dreamcore.utils.scheduler
 import net.perfectdreams.dreamcore.utils.serializer.UUIDAsStringSerializer
 import net.perfectdreams.dreamterrainadditions.commands.*
 import net.perfectdreams.dreamterrainadditions.commands.declarations.TempTrustCommand
@@ -210,7 +208,6 @@ class DreamTerrainAdditions : KotlinPlugin(), Listener {
 	fun onBlockGrowth(e: BlockGrowEvent) {
 		val entityClaim = GriefPrevention.instance.dataStore.getClaimAt(e.block.location, false, null) ?: return
 		val cropsGrowthDisabled = getClaimAdditionsById(entityClaim.id)?.disableCropGrowth ?: return
-
 		if (cropsGrowthDisabled) {
 			e.isCancelled = true
 		}
@@ -218,7 +215,7 @@ class DreamTerrainAdditions : KotlinPlugin(), Listener {
 
 	@EventHandler
 	fun onBlockSpread(event: BlockSpreadEvent) {
-		if (event.source.type == Material.BROWN_MUSHROOM|| event.block.type == Material.RED_MUSHROOM || event.block.type == Material.VINE) {
+		if (event.source.type == Material.BROWN_MUSHROOM || event.source.type == Material.RED_MUSHROOM || event.source.type == Material.VINE) {
 			val entityClaim = GriefPrevention.instance.dataStore.getClaimAt(event.block.location, false, null) ?: return
 			val plantsSpreadingDisabled = getClaimAdditionsById(entityClaim.id)?.disablePlantsSpreading ?: return
 			if (plantsSpreadingDisabled) {
@@ -266,18 +263,6 @@ class DreamTerrainAdditions : KotlinPlugin(), Listener {
 			if (disableTrapdoorAndDoorAccess)
 				e.isCancelled = true
 
-		}
-	}
-
-	@EventHandler
-	fun onTrustChange(event: TrustChangedEvent) {
-		for (claim in event.claims) {
-			val claimAdditions = getClaimAdditionsById(claim.id) ?: return
-
-			val userUniqueId = DreamUtils.retrieveUserUniqueId(event.identifier)
-			if (claimAdditions.temporaryTrustedPlayers.containsKey(userUniqueId) && !event.isGiven) {
-				claimAdditions.temporaryTrustedPlayers.remove(userUniqueId)
-			}
 		}
 	}
 

--- a/bukkit/DreamTerrainAdditions/src/main/kotlin/net/perfectdreams/dreamterrainadditions/commands/TempTrustExecutor.kt
+++ b/bukkit/DreamTerrainAdditions/src/main/kotlin/net/perfectdreams/dreamterrainadditions/commands/TempTrustExecutor.kt
@@ -51,7 +51,7 @@ class TempTrustExecutor(val plugin: DreamTerrainAdditions): SparklyCommandExecut
             val differenceBetweenTargetAndCurrentTime = wrappedTimeInMillis - System.currentTimeMillis()
 
             if (differenceBetweenTargetAndCurrentTime <= 0 || differenceBetweenTargetAndCurrentTime > MAXIMUM_TRUST_TIME_LIMIT)
-                return@launchAsyncThread player.sendMessage("")
+                return@launchAsyncThread player.sendMessage("§cO tempo especificado é inválido. Lembre-se que o tempo não pode ser maior que 6 meses, nem estar no passado!")
 
             val claimAdditions = plugin.getOrCreateClaimAdditionsWithId(claim.id)
 

--- a/bukkit/DreamTerrainAdditions/src/main/kotlin/net/perfectdreams/dreamterrainadditions/commands/declarations/TempTrustCommand.kt
+++ b/bukkit/DreamTerrainAdditions/src/main/kotlin/net/perfectdreams/dreamterrainadditions/commands/declarations/TempTrustCommand.kt
@@ -6,7 +6,7 @@ import net.perfectdreams.dreamterrainadditions.commands.TempTrustExecutor
 import net.perfectdreams.dreamterrainadditions.commands.TempTrustListExecutor
 
 object TempTrustCommand: SparklyCommandDeclarationWrapper {
-    override fun declaration() = sparklyCommand(listOf("temptrust")) {
+    override fun declaration() = sparklyCommand(listOf("temptrust", "trusttemp")) {
         executor = TempTrustExecutor
         subcommand(listOf("list")) {
             executor = TempTrustListExecutor


### PR DESCRIPTION
This issue happens because of the `TrustChangedEvent` event handler, which is causing the listener not to be registered in runtime due to the mentioned class "not existing".

Beyond that, a bug where vines were able to spread even when not allowed to do so was fixed as well. I also took the liberty to add the `/trusttemp` alias to the TempTrust command and fix blank messages showing up when the command was executed.

To expand on the first topic, the `TrustChangedEvent` event handler was not even working properly from the start. It's not called a single time and sometimes even causes the entire listener to malfunction.