### PR TITLE
Don't use snapshots for Ender Hopper

### DIFF
--- a/bukkit/DreamEnderHopper/src/main/kotlin/net/perfectdreams/dreamenderhopper/listeners/EnderHopperListener.kt
+++ b/bukkit/DreamEnderHopper/src/main/kotlin/net/perfectdreams/dreamenderhopper/listeners/EnderHopperListener.kt
@@ -348,7 +348,7 @@ class EnderHopperListener(val m: DreamEnderHopper) : Listener {
     }
 
     private fun getEnderHopperInformation(inventory: Inventory): EnderHopperResult {
-        val holder = inventory.holder ?: return NotAnEnderHopper
+        val holder = inventory.getHolder(false) ?: return NotAnEnderHopper
         if (holder !is Hopper)
             return NotAnEnderHopper
 


### PR DESCRIPTION
Small optimization because creating a snapshot is kinda expensive, especially because the event is triggered multiple times