### PR TITLE
Fix tpanegar not denying pending TPA / TPA Here requests

### DIFF
--- a/bukkit/DreamMini/src/main/kotlin/net/perfectdreams/dreammini/commands/TpaNegarCommand.kt
+++ b/bukkit/DreamMini/src/main/kotlin/net/perfectdreams/dreammini/commands/TpaNegarCommand.kt
@@ -12,14 +12,18 @@ class TpaNegarCommand(val m: DreamMini) : SparklyCommand(arrayOf("tpnegar", "tpa
 		val tpaRequest = m.tpaManager.requests.firstOrNull { it.playerThatWillBeTeleported == sender }
 		val tpaHereRequest = m.tpaManager.hereRequests.firstOrNull { it.playerThatWillBeTeleported == sender }
 
-		if (tpaRequest == null || tpaHereRequest == null) {
+		if (tpaRequest == null && tpaHereRequest == null) {
 			sender.sendMessage("§cVocê não tem nenhum pedido de teletransporte pendente!")
 			return
 		}
 
-		val requester = tpaRequest?.playerThatRequestedTheTeleport ?: tpaHereRequest.playerThatRequestedTheTeleport
-		sender.sendMessage("§aVocê rejeitou o pedido de teletransporte de §b${requester.displayName}§a!")
-		requester.sendMessage("§b${sender.displayName}§c rejeitou o seu pedido de teletransporte!")
+		val requester = tpaRequest?.playerThatRequestedTheTeleport ?: tpaHereRequest?.playerThatRequestedTheTeleport
+		sender.sendMessage("§aVocê rejeitou o pedido de teletransporte de §b${requester?.displayName}§a!")
+		requester?.sendMessage("§b${sender.displayName}§c rejeitou o seu pedido de teletransporte!")
+
+		// Remove request from pool (it'll either remove one of two)
+		m.tpaManager.requests.remove(tpaRequest)
+		m.tpaManager.hereRequests.remove(tpaHereRequest)
 		return
 	}
 }


### PR DESCRIPTION
- Changed validation of pending TPA / TPA Here requests, since it was failing if the user had a pending TPA request, but didn't have a TPA Here request, thus not being able to deny it 
- Removing the TPA / TPA Here request from the pool of requests, so that the user can't, by accident, receive a second TPA / TPA Here request, doing /tpaceitar, and ending up accepting the previous TPA / TPA Here request that they didn't want to accept.